### PR TITLE
fixes text overflow on Galaxy Fold dimensions

### DIFF
--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -2,7 +2,7 @@
 	import logo from '$lib/images/elac-logo.svg';
 </script>
 
-<header class="sticky top-0  z-10" id="nav">
+<header class="sticky top-0 z-10" id="nav">
 	<nav>
 		<div class="navbar bg-secondary">
 			<div class="navbar-start">
@@ -33,8 +33,7 @@
 						<li><a href="#contact">Contact</a></li>
 					</ul>
 				</div>
-				<!-- href needs to be switched to root path -->
-				<a href="#app" class="btn btn-ghost normal-case text-xl">Huskies Computer Club</a>
+				<a href="#app" class="btn btn-ghost normal-case text-lg">Huskies Comp Club</a>
 			</div>
 
 			<div class="navbar-center hidden lg:flex">


### PR DESCRIPTION
# Description
Shortens site navigation title from Huskies Computer Club to Huskies Comp Club
Reduces title text size from extra-large to large.

Fixes #13 


## Screenshots
![Screen Shot 2023-08-21 at 1 13 11 AM](https://github.com/elac-huskies-computer-club/huskies-club-site/assets/36746854/8f387482-2ad9-469c-88ab-5834a7f02aa6)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Cleaning Code Up ( keeping it DRY )
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status

- [X] Complete, tested, ready to review and merge
- [ ] Work-in-Progress, PR is for discussion/feedback

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] There are no merge conflicts
- [ ] I have made corresponding changes to the documentation
